### PR TITLE
Pagination

### DIFF
--- a/client/src/TotaliserText.js
+++ b/client/src/TotaliserText.js
@@ -1,6 +1,6 @@
 import React from "react";
 import styled from "styled-components";
-import { useSpring, animated } from "react-spring";
+import { useSpring, animated, config } from "react-spring";
 
 const Wrapper = styled.div`
   position: absolute;
@@ -64,10 +64,13 @@ const BigText = styled.div`
 `;
 
 const TotaliserText = props => {
-  const { today, yesterday } = useSpring({
-    today: props.totals.today,
-    yesterday: props.totals.yesterday
-  });
+  const { today, yesterday } = useSpring(
+    {
+      today: props.totals.today,
+      yesterday: props.totals.yesterday
+    },
+    { config: config.slow }
+  );
   return (
     <Wrapper>
       <FlexWrapper>

--- a/server/socket.js
+++ b/server/socket.js
@@ -1,32 +1,19 @@
 const shopify = require("./shopify");
 const AsyncPolling = require("async-polling");
-
-const getToday = () => {
-  const date = new Date();
-  date.setHours(0, 0, 0, 0);
-  return date.toISOString();
-};
-
-const getYesterday = () => {
-  const date = new Date();
-  date.setHours(0, 0, 0, 0);
-  date.setDate(date.getDate() - 1);
-  return date.toISOString();
-};
-
-getDateFromString = str =>
-  ({
-    today: getToday(),
-    yesterday: getYesterday()
-  }[str]);
+const { getDateFromString, paginate } = require("./utils");
 
 const getOrdersTotal = (store, from, to) =>
-  store.order
-    .list({
+  paginate(
+    {
+      limit: 250,
+      status: "any",
+      fulfillment_status: "fulfilled",
       financial_status: "paid",
       created_at_min: getDateFromString(from),
       created_at_max: getDateFromString(to)
-    })
+    },
+    params => store.order.list(params)
+  )
     .then(orders =>
       orders.reduce((acc, order, index) => acc + Number(order.total_price), 0)
     )

--- a/server/socket.js
+++ b/server/socket.js
@@ -7,7 +7,6 @@ const getOrdersTotal = (store, from, to) =>
     {
       limit: 250,
       status: "any",
-      fulfillment_status: "fulfilled",
       financial_status: "paid",
       created_at_min: getDateFromString(from),
       created_at_max: getDateFromString(to)

--- a/server/socket.js
+++ b/server/socket.js
@@ -8,6 +8,7 @@ const getOrdersTotal = (store, from, to) =>
       limit: 250,
       status: "any",
       financial_status: "paid",
+      fulfillment_status: "shipped",
       created_at_min: getDateFromString(from),
       created_at_max: getDateFromString(to)
     },
@@ -49,7 +50,7 @@ module.exports = io => {
         getOrdersTotal(store, "today")
           .then(result => end(null, result))
           .catch(end);
-      }, 2000);
+      }, 1500);
       pollers[storeName].run();
     }
 

--- a/server/utils.js
+++ b/server/utils.js
@@ -1,27 +1,30 @@
-const createPoll = (fn, interval) => {
-  const subscribers = {};
-  const intervals = {};
-  return ({ getKey, args, onSuccess }) => {
-    const key = getKey();
-    if (!subscribers[key]) {
-      subscribers[key] = [];
-    }
-    const index = subscribers[key].push(onSuccess) - 1;
-    if (!intervals[key]) {
-      intervals[key] = setInterval(() => {
-        if (subscribers[key].length < 1) {
-          clearInterval(intervals[key]);
-          intervals[key] = null;
-        }
-        fn(...args).then((...args) =>
-          subscribers[key].forEach(s => s(...args))
-        );
-      }, interval);
-    }
-    return () => {
-      subscribers[key].splice(index, 1);
-    };
-  };
+const getToday = () => {
+  const date = new Date();
+  date.setHours(0, 0, 0, 0);
+  return date.toISOString();
 };
 
-module.exports = { createPoll };
+const getYesterday = () => {
+  const date = new Date();
+  date.setHours(0, 0, 0, 0);
+  date.setDate(date.getDate() - 1);
+  return date.toISOString();
+};
+
+const getDateFromString = str =>
+  ({
+    today: getToday(),
+    yesterday: getYesterday()
+  }[str]);
+
+const paginate = async (params, request) => {
+  let responses = [];
+  do {
+    const response = await request(params);
+    responses = [...responses, ...response];
+    params = response.nextPageParameters;
+  } while (params !== undefined);
+  return responses;
+};
+
+module.exports = { getToday, getYesterday, getDateFromString, paginate };


### PR DESCRIPTION
Handles paginated responses from Shopify. This ensures that when the order limit is reached for one response, we get the next set of orders, to ensure that we sum up all the totals for that day - even busy shopping days!